### PR TITLE
Reduce bootstrap onboarding friction with unified preflight and platform fixes

### DIFF
--- a/cmd/bootstrap/bootstrap.go
+++ b/cmd/bootstrap/bootstrap.go
@@ -13,8 +13,9 @@ func GetBootstrapCmd() *cobra.Command {
 		Long: `Bootstrap Complete OpenFrame Environment
 
 This command performs a complete OpenFrame setup by running:
-1. openframe cluster create - Creates a Kubernetes cluster
-2. openframe chart install - Installs ArgoCD and OpenFrame charts
+1. Pre-flight check - Validates ALL prerequisites (tools, memory, certificates) upfront
+2. openframe cluster create - Creates a Kubernetes cluster
+3. openframe chart install - Installs ArgoCD and OpenFrame charts
 
 This is equivalent to running both commands sequentially but provides
 a streamlined experience for getting started with OpenFrame.
@@ -25,18 +26,23 @@ Examples:
   openframe bootstrap --deployment-mode=oss-tenant     # Skip deployment selection
   openframe bootstrap --deployment-mode=saas-shared --non-interactive  # Full CI/CD mode
   openframe bootstrap --verbose                         # Show detailed logs including ArgoCD sync progress
-  openframe bootstrap -v --deployment-mode=oss-tenant  # Verbose mode with pre-selected deployment`,
+  openframe bootstrap -v --deployment-mode=oss-tenant  # Verbose mode with pre-selected deployment
+  openframe bootstrap --repo=https://github.com/myorg/myrepo --branch=dev  # Custom repository`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Logo will be shown by cluster wrapper before prerequisites
 			return bootstrap.NewService().Execute(cmd, args)
 		},
 	}
 
-	// Add deployment mode flags
+	// Deployment configuration
 	cmd.Flags().String("deployment-mode", "", "Deployment mode: oss-tenant, saas-tenant, saas-shared (skips deployment selection)")
 	cmd.Flags().Bool("non-interactive", false, "Skip all prompts, use existing helm-values.yaml")
 	cmd.Flags().BoolP("verbose", "v", false, "Show detailed logging including ArgoCD sync progress")
+	cmd.Flags().Bool("force", false, "Continue even with insufficient memory or other warnings")
+
+	// Repository overrides (useful for contributors working on forks)
+	cmd.Flags().String("repo", "", "Override the default GitHub repository URL")
+	cmd.Flags().String("branch", "", "Override the default Git branch (default: main)")
 
 	return cmd
 }

--- a/internal/bootstrap/preflight.go
+++ b/internal/bootstrap/preflight.go
@@ -1,0 +1,331 @@
+package bootstrap
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	chartCerts "github.com/flamingo-stack/openframe-cli/internal/chart/prerequisites/certificates"
+	chartGit "github.com/flamingo-stack/openframe-cli/internal/chart/prerequisites/git"
+	chartHelm "github.com/flamingo-stack/openframe-cli/internal/chart/prerequisites/helm"
+	chartMemory "github.com/flamingo-stack/openframe-cli/internal/chart/prerequisites/memory"
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/prerequisites/docker"
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/prerequisites/k3d"
+	"github.com/flamingo-stack/openframe-cli/internal/cluster/prerequisites/kubectl"
+	sharedErrors "github.com/flamingo-stack/openframe-cli/internal/shared/errors"
+	"github.com/flamingo-stack/openframe-cli/internal/shared/ui"
+	"github.com/pterm/pterm"
+)
+
+// PreflightChecker runs all prerequisite checks upfront before any work begins.
+// This unifies the cluster and chart prerequisite gates so users don't create a
+// cluster only to fail on chart prerequisites.
+type PreflightChecker struct {
+	nonInteractive bool
+	force          bool
+	verbose        bool
+}
+
+// NewPreflightChecker creates a new unified preflight checker.
+func NewPreflightChecker(nonInteractive, force, verbose bool) *PreflightChecker {
+	return &PreflightChecker{
+		nonInteractive: nonInteractive,
+		force:          force,
+		verbose:        verbose,
+	}
+}
+
+// preflightTool represents a tool to check during preflight.
+type preflightTool struct {
+	Name        string
+	Category    string // "cluster" or "chart"
+	IsInstalled func() bool
+	InstallHelp func() string
+	Installable bool // false for things like memory
+}
+
+// CheckAll runs all prerequisite checks and installs missing tools.
+// It checks cluster prerequisites (Docker, kubectl, k3d, helm) and chart
+// prerequisites (git, helm, memory, certificates) in a single pass.
+func (p *PreflightChecker) CheckAll() error {
+	// Phase 1: Check memory upfront — fail fast if insufficient
+	if err := p.checkMemory(); err != nil {
+		return err
+	}
+
+	// Phase 2: Check all tools
+	tools := p.getAllTools()
+	var missing []preflightTool
+
+	for _, tool := range tools {
+		if !tool.IsInstalled() {
+			missing = append(missing, tool)
+		}
+	}
+
+	if len(missing) == 0 {
+		return nil
+	}
+
+	// Separate truly missing (installable) from Docker-not-running
+	var installable []preflightTool
+	var dockerNotRunning bool
+
+	for _, tool := range missing {
+		if tool.Name == "Docker" {
+			if docker.NewDockerInstaller().IsInstalled() {
+				dockerNotRunning = true
+			} else {
+				installable = append(installable, tool)
+			}
+		} else {
+			installable = append(installable, tool)
+		}
+	}
+
+	// Phase 3: Install missing tools
+	if len(installable) > 0 {
+		names := make([]string, len(installable))
+		for i, t := range installable {
+			names[i] = t.Name
+		}
+		pterm.Warning.Printf("Missing Prerequisites: %s\n", strings.Join(names, ", "))
+
+		var confirmed bool
+		if p.nonInteractive {
+			pterm.Info.Println("Auto-installing prerequisites (non-interactive mode)...")
+			confirmed = true
+		} else {
+			var err error
+			confirmed, err = ui.ConfirmActionInteractive("Would you like me to install them automatically?", true)
+			if err := sharedErrors.WrapConfirmationError(err, "failed to get user confirmation"); err != nil {
+				return err
+			}
+		}
+
+		if confirmed {
+			if err := p.installTools(installable); err != nil {
+				if p.nonInteractive {
+					pterm.Warning.Printf("Failed to install some prerequisites: %v\n", err)
+					pterm.Info.Println("Continuing anyway (non-interactive mode)...")
+				} else {
+					return err
+				}
+			}
+		} else {
+			p.showManualInstructions(installable)
+			return fmt.Errorf("prerequisites not installed")
+		}
+	}
+
+	// Phase 4: Start Docker if needed
+	if dockerNotRunning {
+		if err := p.startDocker(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// checkMemory validates system memory against the recommended minimum.
+func (p *PreflightChecker) checkMemory() error {
+	memChecker := chartMemory.NewMemoryChecker()
+	current, recommended, sufficient := memChecker.GetMemoryInfo()
+
+	if !sufficient {
+		pterm.Warning.Printf("Memory Warning: %d MB available, %d MB recommended\n", current, recommended)
+		if p.force {
+			pterm.Info.Println("Continuing anyway (--force specified).")
+			return nil
+		}
+		if p.nonInteractive {
+			pterm.Info.Println("Continuing anyway (non-interactive mode).")
+			return nil
+		}
+		pterm.Info.Println("Charts may not deploy successfully with insufficient memory.")
+		confirmed, err := ui.ConfirmActionInteractive("Continue anyway?", false)
+		if err != nil {
+			return fmt.Errorf("failed to get memory confirmation: %w", err)
+		}
+		if !confirmed {
+			return fmt.Errorf("insufficient memory: %d MB available, %d MB recommended. Use --force to override", current, recommended)
+		}
+	}
+	return nil
+}
+
+// getAllTools returns all prerequisite tools for both cluster and chart phases.
+func (p *PreflightChecker) getAllTools() []preflightTool {
+	return []preflightTool{
+		// Cluster prerequisites
+		{
+			Name:        "Docker",
+			Category:    "cluster",
+			IsInstalled: func() bool { return docker.IsDockerRunning() },
+			InstallHelp: func() string { return docker.NewDockerInstaller().GetInstallHelp() },
+			Installable: true,
+		},
+		{
+			Name:        "kubectl",
+			Category:    "cluster",
+			IsInstalled: func() bool { return kubectl.NewKubectlInstaller().IsInstalled() },
+			InstallHelp: func() string { return kubectl.NewKubectlInstaller().GetInstallHelp() },
+			Installable: true,
+		},
+		{
+			Name:        "k3d",
+			Category:    "cluster",
+			IsInstalled: func() bool { return k3d.NewK3dInstaller().IsInstalled() },
+			InstallHelp: func() string { return k3d.NewK3dInstaller().GetInstallHelp() },
+			Installable: true,
+		},
+		{
+			Name:        "Helm",
+			Category:    "cluster",
+			IsInstalled: func() bool { return chartHelm.NewHelmInstaller().IsInstalled() },
+			InstallHelp: func() string { return chartHelm.NewHelmInstaller().GetInstallHelp() },
+			Installable: true,
+		},
+		// Chart prerequisites (excluding memory — handled separately)
+		{
+			Name:        "Git",
+			Category:    "chart",
+			IsInstalled: func() bool { return chartGit.NewGitChecker().IsInstalled() },
+			InstallHelp: func() string { return chartGit.NewGitChecker().GetInstallInstructions() },
+			Installable: false, // git install is manual
+		},
+		{
+			Name:        "Certificates",
+			Category:    "chart",
+			IsInstalled: func() bool { return chartCerts.NewCertificateInstaller().IsInstalled() },
+			InstallHelp: func() string { return chartCerts.NewCertificateInstaller().GetInstallHelp() },
+			Installable: true,
+		},
+	}
+}
+
+// installTools installs the given list of missing tools.
+func (p *PreflightChecker) installTools(tools []preflightTool) error {
+	for idx, tool := range tools {
+		spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("[%d/%d] Installing %s...", idx+1, len(tools), tool.Name))
+
+		if err := p.installTool(tool); err != nil {
+			if p.nonInteractive {
+				spinner.Warning(fmt.Sprintf("Skipped %s: %v", tool.Name, err))
+				continue
+			}
+			spinner.Fail(fmt.Sprintf("Failed to install %s: %v", tool.Name, err))
+			return fmt.Errorf("failed to install %s: %w", tool.Name, err)
+		}
+
+		spinner.Success(fmt.Sprintf("%s installed successfully", tool.Name))
+	}
+	return nil
+}
+
+// installTool installs a single tool by name.
+func (p *PreflightChecker) installTool(tool preflightTool) error {
+	switch tool.Name {
+	case "Docker":
+		return docker.NewDockerInstaller().Install()
+	case "kubectl":
+		return kubectl.NewKubectlInstaller().Install()
+	case "k3d":
+		return k3d.NewK3dInstaller().Install()
+	case "Helm":
+		return chartHelm.NewHelmInstaller().Install()
+	case "Certificates":
+		if p.nonInteractive {
+			pterm.Info.Println("Skipping certificate generation in non-interactive mode")
+			return nil
+		}
+		return chartCerts.NewCertificateInstaller().Install()
+	case "Git":
+		return fmt.Errorf("git is not installed. %s", chartGit.NewGitChecker().GetInstallInstructions())
+	default:
+		return fmt.Errorf("unknown tool: %s", tool.Name)
+	}
+}
+
+// startDocker attempts to start Docker.
+func (p *PreflightChecker) startDocker() error {
+	if p.nonInteractive {
+		pterm.Warning.Println("Docker is not running.")
+		pterm.Info.Println("Attempting to start Docker automatically (non-interactive mode)...")
+
+		if err := docker.StartDocker(); err != nil {
+			pterm.Warning.Printf("Could not start Docker automatically: %v\n", err)
+			pterm.Info.Println("Docker must be started manually.")
+			return nil
+		}
+
+		spinner, _ := pterm.DefaultSpinner.Start("Waiting for Docker to start...")
+		if err := docker.WaitForDocker(); err != nil {
+			spinner.Warning("Docker failed to start automatically")
+			return nil
+		}
+		spinner.Success("Docker started successfully")
+		return nil
+	}
+
+	pterm.Warning.Println("Docker is not running.")
+	confirmed, err := ui.ConfirmActionInteractive("Would you like me to start Docker for you?", true)
+	if err != nil {
+		return fmt.Errorf("failed to get Docker start confirmation: %w", err)
+	}
+
+	if confirmed {
+		if err := docker.StartDocker(); err != nil {
+			pterm.Error.Printf("Failed to start Docker: %v\n", err)
+			pterm.Info.Println("Please start Docker Desktop manually and try again.")
+			return fmt.Errorf("failed to start Docker: %w", err)
+		}
+		spinner, _ := pterm.DefaultSpinner.Start("Waiting for Docker to start...")
+		if err := docker.WaitForDocker(); err != nil {
+			spinner.Fail("Docker failed to start")
+			return fmt.Errorf("Docker failed to start: %w", err)
+		}
+		spinner.Success("Docker started successfully")
+	} else {
+		p.showDockerStartInstructions()
+		return fmt.Errorf("Docker is not running")
+	}
+
+	return nil
+}
+
+// showManualInstructions displays manual installation instructions for missing tools.
+func (p *PreflightChecker) showManualInstructions(tools []preflightTool) {
+	fmt.Println()
+	pterm.Info.Println("Installation skipped. Here are manual installation instructions:")
+
+	tableData := pterm.TableData{{"Tool", "Installation Instructions"}}
+	for _, tool := range tools {
+		help := tool.InstallHelp()
+		parts := strings.SplitN(help, ": ", 2)
+		if len(parts) == 2 {
+			tableData = append(tableData, []string{pterm.Cyan(parts[0]), parts[1]})
+		} else {
+			tableData = append(tableData, []string{pterm.Cyan(tool.Name), help})
+		}
+	}
+
+	pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
+}
+
+// showDockerStartInstructions displays platform-specific Docker start instructions.
+func (p *PreflightChecker) showDockerStartInstructions() {
+	fmt.Println()
+	pterm.Info.Println("Please start Docker manually and try again:")
+	switch runtime.GOOS {
+	case "darwin":
+		pterm.Printf("  Open Docker Desktop or run: %s\n", pterm.Cyan("open -a Docker"))
+	case "linux":
+		pterm.Printf("  %s\n", pterm.Cyan("sudo systemctl start docker"))
+	case "windows":
+		pterm.Printf("  Start Docker Desktop from Start Menu\n")
+	default:
+		pterm.Printf("  Verify Docker is running: %s\n", pterm.Cyan("docker ps"))
+	}
+}

--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flamingo-stack/openframe-cli/internal/cluster"
 	"github.com/flamingo-stack/openframe-cli/internal/cluster/models"
 	sharedErrors "github.com/flamingo-stack/openframe-cli/internal/shared/errors"
+	"github.com/flamingo-stack/openframe-cli/internal/shared/ui"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/rest"
 )
@@ -47,6 +48,22 @@ func (s *Service) Execute(cmd *cobra.Command, args []string) error {
 		nonInteractive = false
 	}
 
+	force, err := cmd.Flags().GetBool("force")
+	if err != nil {
+		force = false
+	}
+
+	// Get repo/branch overrides
+	githubRepo, err := cmd.Flags().GetString("repo")
+	if err != nil {
+		githubRepo = ""
+	}
+
+	githubBranch, err := cmd.Flags().GetString("branch")
+	if err != nil {
+		githubBranch = ""
+	}
+
 	// Validate deployment mode
 	if deploymentMode != "" {
 		validModes := []string{"oss-tenant", "saas-tenant", "saas-shared"}
@@ -73,7 +90,7 @@ func (s *Service) Execute(cmd *cobra.Command, args []string) error {
 		clusterName = strings.TrimSpace(args[0])
 	}
 
-	err = s.bootstrap(clusterName, deploymentMode, nonInteractive, verbose)
+	err = s.bootstrap(clusterName, deploymentMode, nonInteractive, force, verbose, githubRepo, githubBranch)
 	if err != nil {
 		// Use shared error handler for consistent error display (same as chart install)
 		return sharedErrors.HandleGlobalError(err, verbose)
@@ -82,7 +99,10 @@ func (s *Service) Execute(cmd *cobra.Command, args []string) error {
 }
 
 // bootstrap executes cluster create followed by chart install
-func (s *Service) bootstrap(clusterName, deploymentMode string, nonInteractive, verbose bool) error {
+func (s *Service) bootstrap(clusterName, deploymentMode string, nonInteractive, force, verbose bool, githubRepo, githubBranch string) error {
+	// Show logo first
+	ui.ShowLogo()
+
 	// On Windows, initialize WSL2 first before anything else
 	if runtime.GOOS == "windows" {
 		if err := s.initializeWSL(verbose); err != nil {
@@ -90,12 +110,20 @@ func (s *Service) bootstrap(clusterName, deploymentMode string, nonInteractive, 
 		}
 	}
 
+	// Unified pre-flight check: verify ALL prerequisites (cluster + chart) before
+	// creating a cluster. This prevents the user from waiting 5-10 minutes for
+	// cluster creation only to fail on chart prerequisites like memory or mkcert.
+	preflight := NewPreflightChecker(nonInteractive, force, verbose)
+	if err := preflight.CheckAll(); err != nil {
+		return err
+	}
+
 	// Normalize cluster name (use default if empty)
 	config := s.buildClusterConfig(clusterName)
 	actualClusterName := config.Name
 
-	// Step 1: Create cluster with suppressed UI and get the rest.Config
-	kubeConfig, err := s.createClusterSuppressed(actualClusterName, verbose, nonInteractive)
+	// Step 1: Create cluster (skip prerequisite checks — already done above)
+	kubeConfig, err := s.createClusterSkipPrereqs(actualClusterName, verbose, nonInteractive)
 	if err != nil {
 		return fmt.Errorf("failed to create cluster: %w", err)
 	}
@@ -105,18 +133,18 @@ func (s *Service) bootstrap(clusterName, deploymentMode string, nonInteractive, 
 	fmt.Println()
 
 	// Step 2: Install charts with deployment mode flags on the created cluster
-	if err := s.installChartWithMode(actualClusterName, deploymentMode, nonInteractive, verbose, kubeConfig); err != nil {
+	// Skip chart prerequisites — already checked by preflight
+	if err := s.installChartWithMode(actualClusterName, deploymentMode, nonInteractive, verbose, kubeConfig, githubRepo, githubBranch); err != nil {
 		return fmt.Errorf("failed to install charts: %w", err)
 	}
 
 	return nil
 }
 
-// createClusterSuppressed creates a cluster with suppressed UI elements
-// Returns the *rest.Config for the created cluster
-func (s *Service) createClusterSuppressed(clusterName string, verbose bool, nonInteractive bool) (*rest.Config, error) {
-	// Use the wrapper function that includes prerequisite checks
-	return cluster.CreateClusterWithPrerequisitesNonInteractive(clusterName, verbose, nonInteractive)
+// createClusterSkipPrereqs creates a cluster without re-running prerequisite checks.
+// Prerequisites have already been verified by the unified preflight checker.
+func (s *Service) createClusterSkipPrereqs(clusterName string, verbose bool, nonInteractive bool) (*rest.Config, error) {
+	return cluster.CreateClusterSkipPrerequisites(clusterName, verbose, nonInteractive)
 }
 
 // buildClusterConfig builds a cluster configuration from the cluster name
@@ -134,19 +162,28 @@ func (s *Service) buildClusterConfig(clusterName string) models.ClusterConfig {
 }
 
 // installChartWithMode installs charts with deployment mode flags
-func (s *Service) installChartWithMode(clusterName, deploymentMode string, nonInteractive, verbose bool, kubeConfig *rest.Config) error {
-	// Use the chart installation function with deployment mode flags
+func (s *Service) installChartWithMode(clusterName, deploymentMode string, nonInteractive, verbose bool, kubeConfig *rest.Config, githubRepo, githubBranch string) error {
+	// Determine repo URL — use override if provided, otherwise derive from deployment mode
+	if githubRepo == "" {
+		githubRepo = "https://github.com/flamingo-stack/openframe-oss-tenant"
+	}
+	if githubBranch == "" {
+		githubBranch = "main"
+	}
+
 	return chartServices.InstallChartsWithConfig(utilTypes.InstallationRequest{
-		Args:           []string{clusterName},
-		Force:          false,
-		DryRun:         false,
-		Verbose:        verbose,
-		GitHubRepo:     "https://github.com/flamingo-stack/openframe-oss-tenant", // Default repository
-		GitHubBranch:   "main",                                                   // Default branch
-		CertDir:        "",                                                       // Auto-detected
-		DeploymentMode: deploymentMode,
-		NonInteractive: nonInteractive,
-		KubeConfig:     kubeConfig,
+		Args:              []string{clusterName},
+		Force:             false,
+		DryRun:            false,
+		Verbose:           verbose,
+		GitHubRepo:        githubRepo,
+		GitHubBranch:      githubBranch,
+		CertDir:           "", // Auto-detected
+		DeploymentMode:    deploymentMode,
+		NonInteractive:    nonInteractive,
+		KubeConfig:        kubeConfig,
+		SkipPrerequisites: true,                // Already checked by preflight
+		SkipConfigPrompts: deploymentMode != "", // Skip config mode selection when deployment mode is pre-set
 	})
 }
 

--- a/internal/chart/ui/configuration/wizard.go
+++ b/internal/chart/ui/configuration/wizard.go
@@ -61,3 +61,10 @@ func (w *ConfigurationWizard) ConfigureHelmValuesWithMode(deploymentMode types.D
 
 	return w.configureInteractive(deploymentMode)
 }
+
+// ConfigureHelmValuesWithModeDefaults configures helm values with pre-selected
+// deployment mode using default configuration, skipping all prompts.
+// This is used by bootstrap when --deployment-mode is provided to minimize interaction.
+func (w *ConfigurationWizard) ConfigureHelmValuesWithModeDefaults(deploymentMode types.DeploymentMode) (*types.ChartConfiguration, error) {
+	return w.configureWithDefaults(deploymentMode)
+}

--- a/internal/chart/utils/types/interfaces.go
+++ b/internal/chart/utils/types/interfaces.go
@@ -136,14 +136,16 @@ type StepResult struct {
 
 // InstallationRequest contains all parameters for chart installation
 type InstallationRequest struct {
-	Args           []string
-	Force          bool
-	DryRun         bool
-	Verbose        bool
-	GitHubRepo     string
-	GitHubBranch   string
-	CertDir        string
-	DeploymentMode string       // Deployment mode: "oss-tenant", "saas-tenant", "saas-shared", or empty for interactive
-	NonInteractive bool         // Skip all prompts, use existing helm-values.yaml
-	KubeConfig     *rest.Config // Kubernetes REST config for cluster communication
+	Args              []string
+	Force             bool
+	DryRun            bool
+	Verbose           bool
+	GitHubRepo        string
+	GitHubBranch      string
+	CertDir           string
+	DeploymentMode    string       // Deployment mode: "oss-tenant", "saas-tenant", "saas-shared", or empty for interactive
+	NonInteractive    bool         // Skip all prompts, use existing helm-values.yaml
+	KubeConfig        *rest.Config // Kubernetes REST config for cluster communication
+	SkipPrerequisites bool         // Skip prerequisite checks (already done by caller, e.g. bootstrap preflight)
+	SkipConfigPrompts bool         // Skip config mode selection; auto-use defaults when deployment mode is set
 }

--- a/internal/cluster/service.go
+++ b/internal/cluster/service.go
@@ -763,3 +763,31 @@ func CreateClusterWithPrerequisitesNonInteractive(clusterName string, verbose bo
 	// Create the cluster and return the rest.Config
 	return service.CreateCluster(config)
 }
+
+// CreateClusterSkipPrerequisites creates a cluster without running prerequisite checks.
+// This is used by the bootstrap command which runs its own unified preflight checks.
+// Returns the *rest.Config for the created cluster.
+func CreateClusterSkipPrerequisites(clusterName string, verbose bool, nonInteractive bool) (*rest.Config, error) {
+	// Create service directly without using utils to avoid circular import
+	exec := executor.NewRealCommandExecutor(false, verbose) // dryRun = false
+	var service *ClusterService
+	if nonInteractive {
+		service = NewClusterServiceSuppressed(exec)
+	} else {
+		service = NewClusterService(exec)
+	}
+
+	// Build cluster configuration
+	config := models.ClusterConfig{
+		Name:       clusterName,
+		Type:       models.ClusterTypeK3d,
+		K8sVersion: "",
+		NodeCount:  4,
+	}
+	if clusterName == "" {
+		config.Name = "openframe-dev" // default name
+	}
+
+	// Create the cluster and return the rest.Config
+	return service.CreateCluster(config)
+}


### PR DESCRIPTION
## Summary
- **Unified pre-flight checker**: Validates ALL prerequisites (cluster + chart) before cluster creation, preventing users from waiting 5-10 minutes for cluster creation only to fail on chart prerequisites like memory or mkcert
- **New flags**: `--force` (bypass soft failures), `--repo`/`--branch` (contributor fork support)
- **Platform fixes**: Windows mkcert installs inside WSL2 (was hard error), macOS falls back to binary download when Homebrew is missing, Linux detects runtime architecture instead of hardcoding amd64
- **Reduced prompts**: `SkipPrerequisites`/`SkipConfigPrompts` eliminate redundant checks and config prompts during bootstrap when `--deployment-mode` is provided

## Test plan
- [x] `go build ./...` passes
- [x] All unit tests pass (`go test ./internal/bootstrap/... ./internal/chart/... ./internal/cluster/...`)
- [ ] Manual test: `openframe bootstrap --deployment-mode=oss-tenant` on macOS/Linux/Windows
- [ ] Manual test: `openframe bootstrap --force` with <15GB memory
- [ ] Manual test: `openframe bootstrap --repo=<fork-url> --branch=dev`
